### PR TITLE
Prevent overflow in worker range computation

### DIFF
--- a/ps1/range_regression.cpp
+++ b/ps1/range_regression.cpp
@@ -1,0 +1,54 @@
+#include "helpers.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+void check_ranges(std::uint64_t limit, unsigned int threads) {
+    const std::uint64_t start = 2;
+    assert(limit >= start);
+    const std::uint64_t total = limit - start + 1;
+
+    std::uint64_t sum = 0;
+    std::uint64_t last_begin = start;
+    bool saw_non_empty = false;
+
+    for (unsigned int idx = 0; idx < threads; ++idx) {
+        WorkerSlice slice = compute_worker_slice(start, total, threads, idx);
+        if (slice.count == 0) {
+            if (sum >= total) {
+                assert(slice.begin == start);
+            }
+            continue;
+        }
+
+        assert(slice.begin >= last_begin);
+        assert(slice.begin == start + sum);
+        assert(slice.begin >= start);
+        assert(slice.begin <= limit);
+        assert(slice.count <= total - sum);
+
+        std::uint64_t last_value = slice.begin + (slice.count - 1);
+        assert(last_value <= limit);
+
+        sum += slice.count;
+        last_begin = slice.begin;
+        saw_non_empty = true;
+    }
+
+    assert(saw_non_empty);
+    assert(sum == total);
+}
+
+}
+
+int main() {
+    check_ranges(std::numeric_limits<std::uint64_t>::max() - 16, 1'000'000);
+    check_ranges(std::numeric_limits<std::uint64_t>::max() - 16, 64);
+    check_ranges(1000, 10);
+    check_ranges(1000, 1500);
+    check_ranges(10, 32);
+    return 0;
+}

--- a/ps1/v1.cpp
+++ b/ps1/v1.cpp
@@ -16,11 +16,10 @@ int main() {
 
     std::uint64_t total = end - start + 1;
     auto worker = [&](unsigned idx){
-        std::uint64_t a = start + (total * idx) / cfg.threads;
-        std::uint64_t b = start + (total * (idx + 1)) / cfg.threads;
-        if (b > end + 1) b = end + 1; 
-        if (a >= b) return;          
-        for (std::uint64_t n = a; n < b; ++n) {
+        auto slice = compute_worker_slice(start, total, cfg.threads, idx);
+        if (slice.count == 0) return;
+        for (std::uint64_t offset = 0; offset < slice.count; ++offset) {
+            std::uint64_t n = slice.begin + offset;
             if (is_prime_single(n)) {
                 std::ostringstream oss;
                 oss << "[" << now_timestamp() << "] [thread " << std::this_thread::get_id()

--- a/ps1/v2.cpp
+++ b/ps1/v2.cpp
@@ -12,13 +12,14 @@ int main() {
     std::vector<std::vector<std::uint64_t>> buckets(cfg.threads);
 
     auto worker = [&](unsigned idx){
-        std::uint64_t a = start + (total * idx) / cfg.threads;
-        std::uint64_t b = start + (total * (idx + 1)) / cfg.threads;
-        if (b > end + 1) b = end + 1; 
-        if (a >= b) return;
+        auto slice = compute_worker_slice(start, total, cfg.threads, idx);
+        if (slice.count == 0) return;
         auto& out = buckets[idx];
-        out.reserve((b - a) / 10 + 1);
-        for (std::uint64_t n = a; n < b; ++n) if (is_prime_single(n)) out.push_back(n);
+        out.reserve(slice.count / 10 + 1);
+        for (std::uint64_t offset = 0; offset < slice.count; ++offset) {
+            std::uint64_t n = slice.begin + offset;
+            if (is_prime_single(n)) out.push_back(n);
+        }
     };
 
     for (unsigned i = 0; i < cfg.threads; ++i) workers.emplace_back(worker, i);


### PR DESCRIPTION
- add a reusable helper that splits the [2, limit] interval without overflowing
- update v1 and v2 to use the helper instead of multiplying large 64-bit integers